### PR TITLE
adding Surface component for displaying Paper vis

### DIFF
--- a/client/src/components/Draw/index.js
+++ b/client/src/components/Draw/index.js
@@ -2,6 +2,7 @@ import paperjs from 'paper'
 import React, { Component } from 'react'
 import canvasStyle from './canvasStyle'
 import Button from 'react-bootstrap/lib/Button';
+import Surface from '../Surface'
 
 class Draw extends Component {
 
@@ -10,99 +11,24 @@ class Draw extends Component {
     this.paper = null
   }
 
-  componentDidMount() {
-    const { drawing } = this.props;
-    const canvas = drawing.canvas;
-
-    if (!this.paper) {
-      const { canvas } = this.refs;
-      this.paper = new paperjs.PaperScope();
-      this.paper.setup(canvas);
-      this.paper.view.play();
-      this.forceUpdate();
-    }
-
-    if ( !this.tool ) {
-      this.tool = new paperjs.Tool();
-      this.tool.onMouseDown = this.onMouseDown.bind(this)
-      this.tool.onMouseDrag = this.onMouseDrag.bind(this)
-      this.tool.onMouseUp = this.onMouseUp.bind(this)
-    }
-
-    this.paper.project.importJSON(canvas)
-  }
-
   render() {
     const {drawing, saving, width, height} = this.props;
     const style = Object.assign(canvasStyle, { width, height})
-    return <div>
-      <canvas ref="canvas" style={style} />
-      <div>
-        <Button
-          type="button"
-          children="Undo"
-          onTouchTap={() => this.undo()}
-        />
-        <Button
-          type="button"
-          children="Commit"
-          onTouchTap={() => this.commit()}
-        />
-        { saving && 'saving...'}
-      </div>
-    </div>
-  }
-
-  undo() {
-    this.removePath()
-  }
-
-  commit() {
-    this.props.onCommit();
-  }
-
-  save() {
-    this.props.onSave(this.paper.project.exportJSON());
-  }
-
-  getCurrentPath() {
-    const paths = this.allPaths()
-    return paths[paths.length - 1]
-  }
-
-  allPaths() {
-    return this.paper && this.paper.project ? this.paper.project.activeLayer.children || [] : []
-  }
-
-  addPath() {
-    const path = new this.paper.Path();
-    path.strokeColor = 'black';
-    path.strokeWidth = 2;
-  }
-
-  removePath() {
-    const currentPath = this.getCurrentPath()
-    if (currentPath) currentPath.remove();
-  }
-
-  onMouseDown(event) {
-    this.addPath();
-  }
-
-  onMouseDrag(event) {
-    const path = this.getCurrentPath()
-    path.add(event.point);
-  }
-
-  onMouseUp(event) {
-    this.getCurrentPath().simplify();
-    this.save()
+    return <Surface
+      drawing={drawing}
+      saving={saving}
+      onSave={this.props.onSave}
+      onCommit={this.props.onCommit}
+      interactive={true}
+    ></Surface>
   }
 }
 
 Draw.propTypes = {
   drawing: React.PropTypes.object,
   onSave: React.PropTypes.func,
+  onCommit: React.PropTypes.func,
+  interactive: React.PropTypes.bool,
 }
 
 export { Draw as default }

--- a/client/src/components/RouteCorpse/index.js
+++ b/client/src/components/RouteCorpse/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import Draw from '../Draw'
+import Surface from '../Surface'
 import { loadCorpse } from 'actions/corpses'
 import { createDrawing } from 'actions/drawings'
 import ListGroup from 'react-bootstrap/lib/ListGroup'
@@ -18,7 +18,7 @@ class Corpse extends React.Component {
 
     if ( loading ) return <Spinner />
     const finalDrawing = canvas ? (
-      <Draw drawing={this.props.corpse} height={200 * 4 + 'px'} />
+      <Surface drawing={this.props.corpse} height={200 * 4 + 'px'} />
     ) : null
 
     return <div><ListGroup>

--- a/client/src/components/Surface/canvasStyle.js
+++ b/client/src/components/Surface/canvasStyle.js
@@ -1,0 +1,6 @@
+export default  {
+  width: '400px',
+  height: '200px',
+  border: '1px solid #eee',
+  backgroundColor: 'white'
+};

--- a/client/src/components/Surface/index.js
+++ b/client/src/components/Surface/index.js
@@ -1,0 +1,113 @@
+import paperjs from 'paper'
+import React, { Component } from 'react'
+import canvasStyle from './canvasStyle'
+import Button from 'react-bootstrap/lib/Button';
+
+class Surface extends Component {
+
+  constructor() {
+    super()
+    this.paper = null
+  }
+
+  componentDidMount() {
+    const { drawing, interactive } = this.props;
+    const canvas = drawing.canvas;
+
+    if (!this.paper) {
+      const { canvas } = this.refs;
+      this.paper = new paperjs.PaperScope();
+      this.paper.setup(canvas);
+      this.paper.view.play();
+      this.forceUpdate();
+    }
+    if ( !this.tool && interactive ) {
+      this.tool = new paperjs.Tool();
+      this.tool.onMouseDown = this.onMouseDown.bind(this)
+      this.tool.onMouseDrag = this.onMouseDrag.bind(this)
+      this.tool.onMouseUp = this.onMouseUp.bind(this)
+    }
+
+    this.paper.project.importJSON(canvas)
+  }
+
+  render() {
+    const {drawing, saving, width, height, interactive} = this.props;
+    const style = Object.assign(canvasStyle, { width, height})
+    return <div>
+      <canvas ref="canvas" style={style} />
+      { interactive ?
+        <div>
+          <Button
+            type="button"
+            children="Undo"
+            onTouchTap={() => this.undo()}
+          />
+          <Button
+            type="button"
+            children="Commit"
+            onTouchTap={() => this.commit()}
+          />
+          { saving && 'saving...'}
+        </div>
+        : null
+      }
+    </div>
+  }
+
+  undo() {
+    this.removePath()
+  }
+
+  commit() {
+    this.props.onCommit();
+  }
+
+  save() {
+    this.props.onSave(this.paper.project.exportJSON());
+  }
+
+  getCurrentPath() {
+    const paths = this.allPaths()
+    return paths[paths.length - 1]
+  }
+
+  allPaths() {
+    return this.paper && this.paper.project ? this.paper.project.activeLayer.children || [] : []
+  }
+
+  addPath() {
+    const path = new this.paper.Path();
+    path.strokeColor = 'black';
+    path.strokeWidth = 2;
+  }
+
+  removePath() {
+    const currentPath = this.getCurrentPath()
+    if (currentPath) currentPath.remove();
+  }
+
+  onMouseDown(event) {
+    this.addPath();
+  }
+
+  onMouseDrag(event) {
+    const path = this.getCurrentPath()
+    path.add(event.point);
+  }
+
+  onMouseUp(event) {
+    this.getCurrentPath().simplify();
+    this.save()
+  }
+}
+
+Surface.propTypes = {
+  drawing: React.PropTypes.object,
+  onSave: React.PropTypes.func,
+  onSave: React.PropTypes.func,
+  onCommit: React.PropTypes.func,
+  interactive: React.PropTypes.bool,
+}
+
+export { Surface as default }


### PR DESCRIPTION
@dmdez does this look like an alright refactor? The `Draw` component is just a `Surface` component with the interactive stuff passed to it. This way we can just use a `Surface` to just _display_ Paper visualizations.